### PR TITLE
Add missing Linear System Solvers

### DIFF
--- a/InductionMachine2D/IM_one_pole/model.sif
+++ b/InductionMachine2D/IM_one_pole/model.sif
@@ -231,6 +231,8 @@ Solver 3
   Calculate Magnetic Vector Potential = Logical True
 
   Skip Compute Nonlinear Change = Logical True
+
+  Linear System Solver = Direct
 End
 
 

--- a/InductionMachine2D/IM_one_pole/transient.sif
+++ b/InductionMachine2D/IM_one_pole/transient.sif
@@ -338,6 +338,7 @@ Solver 4
 !  Calculate Magnetic Field Strength = Logical True
   Calculate Magnetic Vector Potential = Logical True
 
+  Linear System Solver = Direct
 End
 
 Solver 5

--- a/InductionMachine2D/IM_one_pole_multislice/transient.sif
+++ b/InductionMachine2D/IM_one_pole_multislice/transient.sif
@@ -334,13 +334,15 @@ Solver 4
 !  Calculate Electric Field = Logical True
 !  Calculate Magnetic Field Strength = Logical True
   Calculate Magnetic Vector Potential = Logical True
-
+ 
+  Linear System Solver = Direct
 End
 
 Solver 5
   Exec Solver = Always
   Equation = CircOutput
   Procedure = "CircuitsAndDynamics" "CircuitsOutput"
+  Linear System Solver = Direct
 End
 
 


### PR DESCRIPTION
Should resolve the `ERROR:: SolveLinearSystem: Give "Linear System Solver", e.g. "iterative" or "direct"` errors reported in https://github.com/ElmerCSC/elmer-elmag/issues/26. Verified by successfully running each of the modified sif simulations.

Note: I get a segfault when trying to run `harmonic.sif`, so couldn't confirm this issue there.